### PR TITLE
Loading the ZIP from HashiCorp's server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs and configures Hashicorp's Terraform tool. We use this role to install 
 Role Variables
 --------------
 
-You can specify a version, default is `0.6.3` by overriding `terraform_version`.
+You can specify a version, default is `0.6.14` by overriding `terraform_version`.
 
 Example Playbook
 ----------------
@@ -22,7 +22,7 @@ To override the version to install:
 ```yaml
     - hosts: servers
       roles:
-         - { role: ateoto.terraform, terraform_version: 0.6.2 }
+         - { role: ateoto.terraform, terraform_version: 0.6.12 }
 ```
 
 Retention of older versions is not under our control, nor is it'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: download terraform
-  get_url: url=https://dl.bintray.com/mitchellh/terraform/terraform_{{ terraform_version }}_linux_amd64.zip dest=/home/{{ ansible_ssh_user }}/terraform.zip
+  get_url: url=https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_linux_amd64.zip  dest=/home/{{ ansible_ssh_user }}/terraform.zip
 
 - name: extract terraform
   sudo: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-terraform_version: 0.6.3
+terraform_version: 0.6.14


### PR DESCRIPTION
As in bintray 0.6.4 just disappeared, let's use HashiCorp's server right away - and it has also all the old versions, too
